### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,7 +32,7 @@ jobs:
     name: 'lint'
     runs-on: 'ubuntu-latest'
     steps:
-      - uses: 'actions/checkout@v4'
+      - uses: 'actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5' # v4.3.1
       - id: variables
         run: |
           MAKEFILE=$(find . -name Makefile -print -quit)

--- a/.github/workflows/periodic-reporter.yaml
+++ b/.github/workflows/periodic-reporter.yaml
@@ -33,7 +33,7 @@ jobs:
     runs-on: 'ubuntu-latest'
 
     steps:
-      - uses: 'actions/github-script@v7'
+      - uses: 'actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b' # v7.1.0
         with:
           script: |-
                   // label for all issues opened by reporter

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -25,7 +25,7 @@ jobs:
     if: github.repository_owner == 'GoogleCloudPlatform' || github.repository_owner == 'terraform-google-modules'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v9
+    - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 7 days'


### PR DESCRIPTION
## SHA Pinning — automated PR

This PR pins all GitHub Actions workflow steps to immutable commit SHAs.

### What changed

All mutable GitHub Actions tag references (e.g. `@v3`) have been replaced with immutable commit SHA pins plus a version comment, for example:

```yaml
# before
- uses: actions/checkout@v4
# after
- uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
```

Dependabot will keep the SHA pins up-to-date – it's natively [supported by GitHub](https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/).

### Why

A mutable tag can be silently re-pointed to a malicious commit. SHA pins guarantee exactly which code runs in CI.  
See: [tj-actions/changed-files incident (March 2025)](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised)

### Review checklist

- [ ] Spot-check a few SHA pins against the upstream action repo
- [ ] Verify CI still passes after merge
- [ ] **Merge into `main`**
