### PR TITLE
chore: add explicit workflow permissions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -27,6 +27,8 @@ concurrency:
   group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   lint:
     name: 'lint'

--- a/.github/workflows/periodic-reporter.yaml
+++ b/.github/workflows/periodic-reporter.yaml
@@ -23,6 +23,8 @@ on:
     - cron: '0 5,17 * * *'
   workflow_dispatch:
 
+permissions: read-all
+
 jobs:
   report:
     if: github.repository_owner == 'GoogleCloudPlatform' || github.repository_owner == 'terraform-google-modules'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,6 +20,8 @@ on:
   schedule:
   - cron: "0 23 * * *"
 
+permissions: read-all
+
 jobs:
   stale:
     if: github.repository_owner == 'GoogleCloudPlatform' || github.repository_owner == 'terraform-google-modules'


### PR DESCRIPTION
## Workflow Permissions — automated PR

GitHub Actions jobs silently inherit write access to your repository when no `permissions:` key is set. This PR locks that down by adding explicit, minimal permissions to every workflow file.

This PR was generated automatically. You own the merge — **verify CI is green first**.

---

### What was changed

- **Regular workflows** — received `permissions: read-all` at the top level (safe read-only baseline)

---


### Checklist

- [ ] CI is green (or failing jobs have been fixed with explicit job-level `permissions:`)
- [ ] **Merge into `main`**

> [!TIP]
> **`read-all` grants more access than most jobs need.** Before merging, consider narrowing it: set `permissions: {}` at the top level and add explicit grants only to jobs that need them. See [available permission scopes](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions).
